### PR TITLE
fix: Prevent Total Ad Time from being Doubled

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -787,7 +787,7 @@ export class MediaSession {
 
     private logAdSummary() {
         if (this.adContent) {
-            if (this.adContent.adStartTimestamp) {
+            if (this.adContent.adStartTimestamp && !this.adContent.adEndTimestamp) {
                 this.adContent.adEndTimestamp = Date.now();
                 this.mediaTotalAdTimeSpent +=
                     this.adContent.adEndTimestamp -


### PR DESCRIPTION
# Summary

Only add to time when endTimestamp hasn't already been set.

TP: #72530
