### PR TITLE
feat: Add Session Custom Attributes for Events

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -35,6 +35,7 @@ import { uuid } from './utils';
  *   'OnDemand'                    // Stream Type (OnDemand, Live, etc.)
  *   true,                         // Log Page Event Toggle (true/false)
  *   true,                         // Log Media Event Toggle (true/false)
+ *   SessionCustomAttributes,      // (optional) Custom Attributes used for each media event within the Media Session
  * )
  * ```
  *
@@ -130,6 +131,7 @@ export class MediaSession {
      * @param streamType A descriptor for the type of stream, i.e. live or on demand
      * @param logPageEvent A flag that toggles sending mParticle Events to Core SDK
      * @param logMediaEvent A flag that toggles sending Media Events to Core SDK
+     * @param SessionAttributes (optional) A set of custom attributes to attach to all media Events created by a Session
      */
     constructor(
         readonly mparticleInstance: MpSDKInstance,
@@ -140,6 +142,7 @@ export class MediaSession {
         readonly streamType: MediaStreamType,
         public logPageEvent = false,
         public logMediaEvent = true,
+        public sessionAttributes?: ModelAttributes,
     ) {
         this.mediaSessionStartTimestamp = Date.now();
     }
@@ -156,12 +159,17 @@ export class MediaSession {
         // Set event option based on options or current state
         this.currentPlayheadPosition =
             options?.currentPlayheadPosition || this.currentPlayheadPosition;
-        this.customAttributes = options?.customAttributes || {};
+
+        // Merge Session Custom Attributes with any other optional Event Attributes.
+        // Event-Level Custom Attributes will override Session Custom Attributes if there is a collison.
+        this.customAttributes = {
+            ...this.sessionAttributes,
+            ...(options?.customAttributes || {}),
+        };
 
         options = {
             currentPlayheadPosition: this.currentPlayheadPosition,
             customAttributes: this.customAttributes,
-            ...options,
         };
 
         return new MediaEvent(
@@ -645,7 +653,8 @@ export class MediaSession {
      *     contentType = ContentType.Video
      *
      *     logPageEvents = false              //optional, defaults to false anyway
-     *     logMediaEvents = false
+     *     logMediaEvents = false             //optional, defaults to false anyway
+     *     sessionCustomEvents = {}           //optional, defaults to empty object
      * );
      *
      * const myCallback = (event: MediaEvent): void => {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -114,7 +114,7 @@ describe('MediaSession', () => {
 
             mpMedia.logAdBreakStart(adBreak, options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
 
@@ -178,7 +178,7 @@ describe('MediaSession', () => {
 
             mpMedia.logAdBreakEnd(options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -263,7 +263,7 @@ describe('MediaSession', () => {
 
             mpMedia.logAdStart(adContent, options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -374,7 +374,7 @@ describe('MediaSession', () => {
 
             mpMedia.logAdEnd(options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -449,7 +449,7 @@ describe('MediaSession', () => {
 
             mpMedia.logAdSkip(options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -516,7 +516,7 @@ describe('MediaSession', () => {
 
             mpMedia.logAdClick(adContent, options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -558,7 +558,7 @@ describe('MediaSession', () => {
 
             mpMedia.logBufferStart(320, 20, 201, options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -600,7 +600,7 @@ describe('MediaSession', () => {
 
             mpMedia.logBufferEnd(99, 2, 341, options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -640,7 +640,7 @@ describe('MediaSession', () => {
 
             mpMedia.logSeekStart(341, options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -680,7 +680,7 @@ describe('MediaSession', () => {
 
             mpMedia.logSeekEnd(111, options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -741,7 +741,7 @@ describe('MediaSession', () => {
 
             mpMedia.logMediaSessionStart(options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -780,7 +780,7 @@ describe('MediaSession', () => {
 
             mpMedia.logMediaSessionEnd(options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -874,7 +874,7 @@ describe('MediaSession', () => {
             };
             mpMedia.logPlay(options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -912,7 +912,7 @@ describe('MediaSession', () => {
             };
             mpMedia.logPause(options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -950,7 +950,7 @@ describe('MediaSession', () => {
             };
             mpMedia.logMediaContentEnd(options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -1016,7 +1016,7 @@ describe('MediaSession', () => {
             };
             mpMedia.logSegmentStart(segment, options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -1079,7 +1079,7 @@ describe('MediaSession', () => {
 
             mpMedia.logSegmentEnd(options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -1141,7 +1141,7 @@ describe('MediaSession', () => {
             };
             mpMedia.logSegmentSkip(options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
@@ -1236,7 +1236,7 @@ describe('MediaSession', () => {
 
             mpMedia.logQoS(qos, options);
 
-            expect(bond.args[0][0].options.customAttributes).to.eq(
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
                 options.customAttributes,
             );
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Add Session Custom Attributes attribute to MediaSession constructor, so that any derived Media Events can have the same attributes
 - Session Events should come through as Event Attributes
 - Events should be able to override these Session level attributes

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - Manual testing:
   - Load Media SDK into a sample app
   - Create a Media Session with Session Attributes
   - Verify that Session Attributes appear in each event
   - Verify that an individual event can override its session attributes via the media session's log methods, i.e. `LogPlay()`

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5228
