### PR TITLE
ci: Set Release job to use Node 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             - name: NPM install ${{ matrix.node-version }}
               uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 14.x
 
             - name: Run NPM CI
               run: npm ci
@@ -99,7 +99,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 14.x
 
             - name: Install dependencies
               run: npm ci


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Set Release job to use Node 14 which is better supported by the current packages

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - N/A as this is a Github Action change

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5264
