### PR TITLE
fix:accept CurrentPlayheadPosition with 0 value

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -160,8 +160,7 @@ export class MediaSession {
         options: Options = {},
     ): MediaEvent {
         // Set event option based on options or current state
-        this.currentPlayheadPosition =
-            options?.currentPlayheadPosition || this.currentPlayheadPosition;
+        this.currentPlayheadPosition = options?.currentPlayheadPosition;
 
         // Merge Session Attributes with any other optional Event Attributes.
         // Event-Level Custom Attributes will override Session Custom Attributes if there is a collison.

--- a/src/session.ts
+++ b/src/session.ts
@@ -160,9 +160,8 @@ export class MediaSession {
         options: Options = {},
     ): MediaEvent {
         // Set event option based on options or current state
-        if (options?.currentPlayheadPosition !== undefined) {
-            this.currentPlayheadPosition = options?.currentPlayheadPosition;
-        }
+        this.currentPlayheadPosition =
+            options?.currentPlayheadPosition ?? this.currentPlayheadPosition;
 
         // Merge Session Attributes with any other optional Event Attributes.
         // Event-Level Custom Attributes will override Session Custom Attributes if there is a collison.

--- a/src/session.ts
+++ b/src/session.ts
@@ -160,7 +160,9 @@ export class MediaSession {
         options: Options = {},
     ): MediaEvent {
         // Set event option based on options or current state
-        this.currentPlayheadPosition = options?.currentPlayheadPosition;
+        if (options?.currentPlayheadPosition !== undefined) {
+            this.currentPlayheadPosition = options?.currentPlayheadPosition;
+        }
 
         // Merge Session Attributes with any other optional Event Attributes.
         // Event-Level Custom Attributes will override Session Custom Attributes if there is a collison.

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -746,6 +746,24 @@ describe('MediaSession', () => {
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
         });
+
+        it('accepts currentPlayheadPosition with a value of 0', () => {
+            const bond = sinon.spy(mp, 'logBaseEvent');
+
+            const options = {
+                currentPlayheadPosition: 0,
+                customAttributes: {
+                    content_rating: 'epic',
+                },
+            };
+
+            mpMedia.logMediaSessionStart(options);
+
+            expect(bond.args[0][0].options.customAttributes).to.eqls(
+                options.customAttributes,
+            );
+            expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(0);
+        });
     });
 
     describe('#logMediaSessionEnd', () => {


### PR DESCRIPTION
 ## Summary
 - A customer reported that when sending a Media Session Start event, the playhead_position will be set to '0' if the user is starting the media session from the beginning of the content which is needed for them since playhead_position marked as a required attribute because they deem it to be integral for all media events, after further investigation it seems that the playhead_position was being dropped due to how JS treats 0 as a false value in a conditional

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - I was able to override the my higgs sample app and change the bundle.js code with the one in this PR and tested both cases where we include a playhead_position and when not.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-6737
