### PR TITLE
feat: Pause mediaContentTimeSpent calculation on ad breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ const mediaSession = new MediaSession(
     true,                         // Log Media Event Toggle (true/false)
     {   
         "my_session_attribute": "My Session Attribute"
-    }    // (optional) Custom Session Attributes object used for each media event within the Media Session
+    },    // (optional) Custom Session Attributes object used for each media event within the Media Session
+    true  // (optional) Exclude Ad breaks from media content time
 )
 
 mediaSession.logMediaSessionStart();

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,14 +89,6 @@ export type AdBreak = {
      * Length of time of the complete ad break
      */
     duration: number;
-    /**
-     * Timestamp for AdBreak start playback
-     */
-    adBreakStartTimestamp?: number;
-    /**
-     * Timestamp for AdBreak end playback
-     */
-    adBreakEndTimestamp?: number;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,14 @@ export type AdBreak = {
      * Length of time of the complete ad break
      */
     duration: number;
+    /**
+     * Timestamp for AdBreak start playback
+     */
+    adBreakStartTimestamp?: number;
+    /**
+     * Timestamp for AdBreak end playback
+     */
+    adBreakEndTimestamp?: number;
 };
 
 /**

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -82,7 +82,7 @@ describe('MediaSession', () => {
             ).to.eql(adBreak);
         });
 
-        it('should not resume after AdBreakEnd if user paused before ad break and excludeAdBreaksFromContentTime is true', async () => {
+        it('should not accumulate mediaContentTimeSpent after AdBreakEnd if user paused before ad break and excludeAdBreaksFromContentTime is true', async () => {
             const customSession: MediaSession = new MediaSession(
                 mp,
                 song.contentId,
@@ -240,7 +240,7 @@ describe('MediaSession', () => {
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
         });
 
-        it('should pause mediaContentTimeSpent when excludeAdBreaksFromContentTime is true', async () => {
+        it('should pause mediaContentTimeSpent when logging ad breaks when excludeAdBreaksFromContentTime is true', async () => {
             const mediaSessionAttributes = {
                 session_name: 'amazing-current-session',
                 session_start_time: 'right-now',
@@ -360,7 +360,7 @@ describe('MediaSession', () => {
             expect(mpMediaContentTimeSpent).to.lessThanOrEqual(400);
         });
 
-        it('should not resume after AdBreakEnd if user paused during ad break and excludeAdBreaksFromContentTime is true', async () => {
+        it('should not accumulate mediaContentTimeSpent after AdBreakEnd if user paused during ad break and excludeAdBreaksFromContentTime is true', async () => {
             const mediaSessionAttributes = {
                 session_name: 'amazing-current-session',
                 session_start_time: 'right-now',

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -421,8 +421,7 @@ describe('MediaSession', () => {
             );
             expect(summaryArg, 'Expected a Session Summary event').to.exist;
             const summaryAttrs = summaryArg?.[0].options.customAttributes;
-            const mediaContentTimeSpent =
-                summaryAttrs.media_content_time_spent;
+            const mediaContentTimeSpent = summaryAttrs.media_content_time_spent;
             // Only pre-ad ~100ms should be counted as content time
             expect(mediaContentTimeSpent).to.greaterThanOrEqual(100);
             expect(mediaContentTimeSpent).to.lessThanOrEqual(220);

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -183,6 +183,126 @@ describe('MediaSession', () => {
             );
             expect(bond.args[0][0].options.currentPlayheadPosition).to.eq(32);
         });
+
+        it('should pause mediaContentTimeSpent when pauseOnAdBreak is true', async () => {
+            const mediaSessionAttributes = {
+                session_name: 'amazing-current-session',
+                session_start_time: 'right-now',
+                custom_session_value: 'this-is-custom',
+            };
+
+            const customSession: MediaSession = new MediaSession(
+                mp,
+                song.contentId,
+                song.title,
+                song.duration,
+                song.contentType,
+                song.streamType,
+                false,
+                true,
+                true,
+                mediaSessionAttributes,
+            );
+
+            const bond = sinon.spy(mp, 'logBaseEvent');
+
+            customSession.logMediaSessionStart();
+
+            const options = {
+                customAttributes: {
+                    content_rating: 'epic',
+                },
+                currentPlayheadPosition: 0,
+            };
+
+            const adBreak: AdBreak = {
+                id: '08123410',
+                title: 'mid-roll',
+                duration: 10000,
+            };
+
+            // logPlay is triggered to start media content time tracking.
+            customSession.logPlay(options);
+            // 100ms delay added to account for the time spent on media content.
+            await new Promise(f => setTimeout(f, 100));
+            customSession.logAdBreakStart(adBreak);
+            // Another 100ms delay added after logPause is triggered to account for time spent on media session (total = +200ms).
+            await new Promise(f => setTimeout(f, 100));
+            customSession.logAdBreakEnd(options);
+            // Another 100ms delay added after logPause is triggered to account for time spent on media session (total = +200ms).
+            await new Promise(f => setTimeout(f, 100));
+            customSession.logMediaSessionEnd(options);
+
+            // the 6th event in bond.args is the Media Session Summary which contains the mediaContentTimeSpent and mediaTimeSpent.
+            const mpMediaContentTimeSpent =
+                bond.args[5][0].options.customAttributes
+                    .media_content_time_spent;
+
+            // the mediaContentTimeSpent varies in value each test run by a millisecond or two (i,e value is could be 100ms, 101ms, 102ms)
+            // and we can't determine the exact value, hence the greaterThanOrEqual and lessThanOrEqual tests.
+            expect(mpMediaContentTimeSpent).to.greaterThanOrEqual(200);
+            expect(mpMediaContentTimeSpent).to.lessThanOrEqual(300);
+        });
+
+        it('should not pause mediaContentTimeSpent when pauseOnAdBreak is false', async () => {
+            const mediaSessionAttributes = {
+                session_name: 'amazing-current-session',
+                session_start_time: 'right-now',
+                custom_session_value: 'this-is-custom',
+            };
+
+            const customSession: MediaSession = new MediaSession(
+                mp,
+                song.contentId,
+                song.title,
+                song.duration,
+                song.contentType,
+                song.streamType,
+                false,
+                true,
+                false,
+                mediaSessionAttributes,
+            );
+
+            const bond = sinon.spy(mp, 'logBaseEvent');
+
+            customSession.logMediaSessionStart();
+
+            const options = {
+                customAttributes: {
+                    content_rating: 'epic',
+                },
+                currentPlayheadPosition: 0,
+            };
+
+            const adBreak: AdBreak = {
+                id: '08123410',
+                title: 'mid-roll',
+                duration: 10000,
+            };
+
+            // logPlay is triggered to start media content time tracking.
+            customSession.logPlay(options);
+            // 100ms delay added to account for the time spent on media content.
+            await new Promise(f => setTimeout(f, 100));
+            customSession.logAdBreakStart(adBreak);
+            // Another 100ms delay added after logPause is triggered to account for time spent on media session (total = +200ms).
+            await new Promise(f => setTimeout(f, 100));
+            customSession.logAdBreakEnd(options);
+            // Another 100ms delay added after logPause is triggered to account for time spent on media session (total = +200ms).
+            await new Promise(f => setTimeout(f, 100));
+            customSession.logMediaSessionEnd(options);
+
+            // the 6th event in bond.args is the Media Session Summary which contains the mediaContentTimeSpent and mediaTimeSpent.
+            const mpMediaContentTimeSpent =
+                bond.args[5][0].options.customAttributes
+                    .media_content_time_spent;
+
+            // the mediaContentTimeSpent varies in value each test run by a millisecond or two (i,e value is could be 100ms, 101ms, 102ms)
+            // and we can't determine the exact value, hence the greaterThanOrEqual and lessThanOrEqual tests.
+            expect(mpMediaContentTimeSpent).to.greaterThanOrEqual(300);
+            expect(mpMediaContentTimeSpent).to.lessThanOrEqual(400);
+        });
     });
 
     describe('#logAdStart', () => {
@@ -1384,6 +1504,7 @@ describe('MediaSession', () => {
                 song.streamType,
                 false,
                 true,
+                false,
                 mediaSessionAttributes,
             );
 
@@ -1408,6 +1529,7 @@ describe('MediaSession', () => {
                 song.streamType,
                 false,
                 true,
+                false,
                 {
                     session_name: 'amazing-current-session',
                     session_start_time: 'right-now',


### PR DESCRIPTION
## Background
- Per this [doc](https://docs.google.com/document/d/1nc1v1JoGBR21F_kBJQgwFhWauw4sfswWLXoIaZs0iO4/edit?tab=t.0#heading=h.klilr1f259te), Currently, the mParticle Media SDK requires developers to manually manage content time tracking during ad breaks, creating additional complexity and potential for error. If not managed appropriately, the media content time spent value is overstated with ad break time. This PR adds an (optional) ability to allow pausing mediaContentTimeSpent when an Ad Break starts and ends

## What Has Changed
- Added a true/false flag (false by default) on the mediaSession init level that when true, mediaContentTimeSpent will be paused when an Ad Break starts and ends, otherwise when false, the mediaConentTimeSpent will stay the same as is

## Screenshots/Video
- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have tested this locally.

## Additional Notes
- same feature will be added to iOS, Android and Roku media SDKs

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/SDKE-446
